### PR TITLE
bump numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ idna==2.8
 Jinja2==2.11.3
 jmespath==0.9.4
 MarkupSafe==1.1.1
-numpy==1.17.2
+numpy==1.20.3
 packaging==19.2
 pandas==0.25.1
 Pillow==8.1.1


### PR DESCRIPTION
The `process-files` command fails with:
```
 from pykdtree.kdtree import KDTree                                                                                                                                                                             
  File "__init__.pxd", line 198, in init pykdtree.kdtree                                                                                                                                                           
ValueError: numpy.ndarray has the wrong size, try recompiling. Expected 80, got 88
```
bumping numpy version seems to solve the issue, but I did not run through the whole process of setting up sqs and running locally. 