### PR TITLE
Using headless-don't need GUI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Jinja2==2.11.3
 jmespath==0.9.4
 MarkupSafe==1.1.1
 numpy==1.20.3
-opencv-python==4.9.0.80
+opencv-python-headless==4.9.0.80
 packaging==19.2
 pandas==0.25.1
 Pillow==8.2.0


### PR DESCRIPTION
see here: https://pypi.org/project/opencv-python/
and here: https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo